### PR TITLE
fix(menu): load menu dynamically only if the user is logged In

### DIFF
--- a/src/app/core/bootstrap/load-menu.service.ts
+++ b/src/app/core/bootstrap/load-menu.service.ts
@@ -1,0 +1,31 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { MenuService } from './menu.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoadMenuService {
+  constructor(private menu: MenuService, private http: HttpClient) {}
+
+  load() {
+    return this.http
+      .get('assets/data/menu.json?_t=' + Date.now())
+      .pipe(
+        catchError(res => {
+          return throwError(res);
+        })
+      )
+      .subscribe(
+        (res: any) => {
+          this.menu.recursMenuForTranslation(res.menu, 'menu');
+          this.menu.set(res.menu);
+        },
+        () => {},
+        () => {}
+      );
+  }
+}

--- a/src/app/core/bootstrap/startup.service.ts
+++ b/src/app/core/bootstrap/startup.service.ts
@@ -13,26 +13,8 @@ export class StartupService {
 
   load(): Promise<any> {
     return new Promise((resolve, reject) => {
-      this.http
-        .get('assets/data/menu.json?_t=' + Date.now())
-        .pipe(
-          catchError(res => {
-            resolve();
-            return throwError(res);
-          })
-        )
-        .subscribe(
-          (res: any) => {
-            this.menu.recursMenuForTranslation(res.menu, 'menu');
-            this.menu.set(res.menu);
-          },
-          () => {
-            reject();
-          },
-          () => {
-            resolve();
-          }
-        );
+      // add function or http calls toload that at the starting of the application
+      resolve();
     });
   }
 }

--- a/src/app/theme/admin-layout/admin-layout.component.ts
+++ b/src/app/theme/admin-layout/admin-layout.component.ts
@@ -18,6 +18,7 @@ import { MatSidenav, MatSidenavContent } from '@angular/material/sidenav';
 
 import { SettingsService, AppSettings } from '@core';
 import { AppDirectionality } from '@shared';
+import { LoadMenuService } from '@core/bootstrap/load-menu.service';
 
 const MOBILE_MEDIAQUERY = 'screen and (max-width: 599px)';
 const TABLET_MEDIAQUERY = 'screen and (min-width: 600px) and (max-width: 959px)';
@@ -64,6 +65,7 @@ export class AdminLayoutComponent implements OnInit, OnDestroy {
     private overlay: OverlayContainer,
     private element: ElementRef,
     private settings: SettingsService,
+    private readonly loadMenu: LoadMenuService,
     @Optional() @Inject(DOCUMENT) private document: Document,
     @Inject(Directionality) public dir: AppDirectionality
   ) {
@@ -90,6 +92,7 @@ export class AdminLayoutComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.loadMenu.load();
     setTimeout(() => (this.contentWidthFix = this.collapsedWidthFix = false));
   }
 


### PR DESCRIPTION
Load the menu only if the user is logged in. Currently even if the user is not logged in then also it is loading the side menu. I have fixed it and created a load menu service that is getting called from the admin layout.