### PR TITLE
refactor: navigate /auth/login when api url is /auth/logout

### DIFF
--- a/src/app/core/authentication/auth.guard.ts
+++ b/src/app/core/authentication/auth.guard.ts
@@ -1,6 +1,13 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
-import { AuthService } from '@core/authentication/auth.service';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  CanActivateChild,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { AuthService } from './auth.service';
 
 @Injectable({
   providedIn: 'root',
@@ -12,7 +19,10 @@ export class AuthGuard implements CanActivate, CanActivateChild {
     return this.authenticate();
   }
 
-  canActivateChild(childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | UrlTree {
+  canActivateChild(
+    childRoute: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): boolean | UrlTree {
     return this.authenticate();
   }
 

--- a/src/app/core/authentication/auth.service.ts
+++ b/src/app/core/authentication/auth.service.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, iif, of } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { map, share, switchMap, tap } from 'rxjs/operators';
-import { TokenService } from '@core/authentication/token.service';
-import { guest, Token, User } from '@core/authentication/interface';
+import { TokenService } from './token.service';
+import { guest, Token, User } from './interface';
 
 @Injectable({
   providedIn: 'root',
@@ -35,10 +35,6 @@ export class AuthService {
   }
 
   logout() {
-    if (!this.check()) {
-      return of(false);
-    }
-
     return this.http.post('/auth/logout', {}).pipe(
       tap(() => this.token.clear()),
       map(() => !this.check())

--- a/src/app/core/authentication/token.service.ts
+++ b/src/app/core/authentication/token.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { share } from 'rxjs/operators';
-import { LocalStorageService } from '@shared';
+import { LocalStorageService } from '../../shared/services/storage.service';
 import { Token } from './interface';
 
 function capitalize(str: string) {

--- a/src/app/core/bootstrap/sanctum.service.spec.ts
+++ b/src/app/core/bootstrap/sanctum.service.spec.ts
@@ -23,8 +23,8 @@ describe('SanctumService', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
-        { provide: BASE_URL, useValue: '' },
-        { provide: SANCTUM_PREFIX, useValue: '' },
+        { provide: BASE_URL, useValue: null },
+        { provide: SANCTUM_PREFIX, useValue: null },
         SanctumService,
       ],
     });
@@ -33,7 +33,7 @@ describe('SanctumService', () => {
   afterEach(() => httpMock.verify());
 
   it('should get csrf cookie once', done => {
-    setBaseUrlAndSanctumPrefix('', '');
+    setBaseUrlAndSanctumPrefix(null, null);
 
     sanctumService.load().then(() => done());
 
@@ -49,7 +49,7 @@ describe('SanctumService', () => {
   });
 
   it('should get csrf cookie with sanctum prefix', done => {
-    setBaseUrlAndSanctumPrefix('', '/foobar/');
+    setBaseUrlAndSanctumPrefix(null, '/foobar/');
 
     sanctumService.load().then(() => done());
 

--- a/src/app/core/bootstrap/sanctum.service.ts
+++ b/src/app/core/bootstrap/sanctum.service.ts
@@ -23,7 +23,8 @@ export class SanctumService {
   }
 
   private getUrl() {
-    const path = `/${this.prefix.replace(/^\/|\/$/g, '') || 'sanctum'}/csrf-cookie`;
+    const prefix = this.prefix || 'sanctum';
+    const path = `/${prefix.replace(/^\/|\/$/g, '')}/csrf-cookie`;
 
     if (!this.baseUrl) {
       return path;

--- a/src/app/core/initializers.ts
+++ b/src/app/core/initializers.ts
@@ -3,7 +3,7 @@ import { APP_INITIALIZER } from '@angular/core';
 import { TranslateLangService } from './bootstrap/translate-lang.service';
 import { StartupService } from './bootstrap/startup.service';
 // import { SanctumService } from './bootstrap/sanctum.service';
-
+//
 // export function SanctumServiceFactory(sanctumService: SanctumService) {
 //   return () => sanctumService.load();
 // }
@@ -15,7 +15,6 @@ export function TranslateLangServiceFactory(translateLangService: TranslateLangS
 export function StartupServiceFactory(startupService: StartupService) {
   return () => startupService.load();
 }
-
 
 export const appInitializerProviders = [
   // {

--- a/src/app/core/interceptors/base-url-interceptor.spec.ts
+++ b/src/app/core/interceptors/base-url-interceptor.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed } from '@angular/core/testing';
 
-import { BASE_URL, BaseUrlInterceptor } from './base-url-interceptor';
 import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { BASE_URL, BaseUrlInterceptor } from './base-url-interceptor';
 
 describe('BaseUrlInterceptor', () => {
   let httpMock: HttpTestingController;

--- a/src/app/core/interceptors/base-url-interceptor.spec.ts
+++ b/src/app/core/interceptors/base-url-interceptor.spec.ts
@@ -19,7 +19,7 @@ describe('BaseUrlInterceptor', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
-        { provide: BASE_URL, useValue: '' },
+        { provide: BASE_URL, useValue: null },
         { provide: HTTP_INTERCEPTORS, useClass: BaseUrlInterceptor, multi: true },
       ],
     });
@@ -28,7 +28,7 @@ describe('BaseUrlInterceptor', () => {
   afterEach(() => httpMock.verify());
 
   it('should not prepend base url when base url is empty', () => {
-    setBaseUrl('');
+    setBaseUrl(null);
 
     http.get('/me').subscribe();
 

--- a/src/app/core/interceptors/error-interceptor.spec.ts
+++ b/src/app/core/interceptors/error-interceptor.spec.ts
@@ -1,11 +1,11 @@
 import { TestBed } from '@angular/core/testing';
 
-import { ErrorInterceptor } from './error-interceptor';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
 import { RouterTestingModule } from '@angular/router/testing';
 import { Router } from '@angular/router';
 import { ToastrModule, ToastrService } from 'ngx-toastr';
+import { ErrorInterceptor } from './error-interceptor';
 
 describe('ErrorInterceptor', () => {
   let httpMock: HttpTestingController;
@@ -24,14 +24,9 @@ describe('ErrorInterceptor', () => {
     });
   }
 
-
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [
-        HttpClientTestingModule,
-        RouterTestingModule,
-        ToastrModule.forRoot(),
-      ],
+      imports: [HttpClientTestingModule, RouterTestingModule, ToastrModule.forRoot()],
       providers: [{ provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true }],
     });
 
@@ -48,14 +43,16 @@ describe('ErrorInterceptor', () => {
 
     http.get('/me').subscribe();
 
-    httpMock.expectOne('/me').flush({ success: true }, {
-      status: 401,
-      statusText: 'Unauthorized',
-    });
+    httpMock.expectOne('/me').flush(
+      { success: true },
+      {
+        status: 401,
+        statusText: 'Unauthorized',
+      }
+    );
 
     expect(router.navigateByUrl).toHaveBeenCalledWith('/auth/login');
   });
-
 
   it('should handle status code 403', () => {
     assertStatus(403, 'Forbidden');
@@ -73,10 +70,13 @@ describe('ErrorInterceptor', () => {
     spyOn(toastr, 'error');
     http.get('/me').subscribe();
 
-    httpMock.expectOne('/me').flush({ success: true }, {
-      status: 504,
-      statusText: 'Gateway Timeout',
-    });
+    httpMock.expectOne('/me').flush(
+      { success: true },
+      {
+        status: 504,
+        statusText: 'Gateway Timeout',
+      }
+    );
 
     expect(toastr.error).toHaveBeenCalledWith('504 Gateway Timeout');
   });

--- a/src/app/core/interceptors/sanctum-interceptor.spec.ts
+++ b/src/app/core/interceptors/sanctum-interceptor.spec.ts
@@ -23,8 +23,8 @@ describe('SanctumInterceptor', () => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
-        { provide: BASE_URL, useValue: '' },
-        { provide: SANCTUM_PREFIX, useValue: '' },
+        { provide: BASE_URL, useValue: null },
+        { provide: SANCTUM_PREFIX, useValue: null },
         { provide: HTTP_INTERCEPTORS, useClass: SanctumInterceptor, multi: true },
       ],
     });
@@ -33,7 +33,7 @@ describe('SanctumInterceptor', () => {
   afterEach(() => httpMock.verify());
 
   it('should get csrf cookie once', () => {
-    setBaseUrlAndSanctumPrefix('', '');
+    setBaseUrlAndSanctumPrefix(null, null);
 
     http
       .post('/auth/login', { username: 'foo', password: 'bar' })
@@ -46,7 +46,7 @@ describe('SanctumInterceptor', () => {
   });
 
   it('should get csrf cookie with base url', () => {
-    setBaseUrlAndSanctumPrefix('http://foo.bar/api', '');
+    setBaseUrlAndSanctumPrefix('http://foo.bar/api', null);
 
     http
       .post('/auth/login', { username: 'foo', password: 'bar' })
@@ -59,7 +59,7 @@ describe('SanctumInterceptor', () => {
   });
 
   it('should get csrf cookie with sanctum prefix', () => {
-    setBaseUrlAndSanctumPrefix('', 'foobar');
+    setBaseUrlAndSanctumPrefix(null, 'foobar');
 
     http
       .post('/auth/login', { username: 'foo', password: 'bar' })

--- a/src/app/core/interceptors/sanctum-interceptor.spec.ts
+++ b/src/app/core/interceptors/sanctum-interceptor.spec.ts
@@ -2,9 +2,9 @@ import { TestBed } from '@angular/core/testing';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { switchMap } from 'rxjs/operators';
 import { SanctumInterceptor } from './sanctum-interceptor';
 import { BASE_URL } from './base-url-interceptor';
-import { switchMap } from 'rxjs/operators';
 import { SANCTUM_PREFIX } from '../bootstrap/sanctum.service';
 
 describe('SanctumInterceptor', () => {
@@ -35,9 +35,10 @@ describe('SanctumInterceptor', () => {
   it('should get csrf cookie once', () => {
     setBaseUrlAndSanctumPrefix('', '');
 
-    http.post('/auth/login', { username: 'foo', password: 'bar' }).pipe(
-      switchMap(() => http.get('/me')),
-    ).subscribe();
+    http
+      .post('/auth/login', { username: 'foo', password: 'bar' })
+      .pipe(switchMap(() => http.get('/me')))
+      .subscribe();
 
     httpMock.expectOne('/sanctum/csrf-cookie').flush({ cookie: true });
     httpMock.expectOne('/auth/login').flush({ login: true });
@@ -47,9 +48,10 @@ describe('SanctumInterceptor', () => {
   it('should get csrf cookie with base url', () => {
     setBaseUrlAndSanctumPrefix('http://foo.bar/api', '');
 
-    http.post('/auth/login', { username: 'foo', password: 'bar' }).pipe(
-      switchMap(() => http.get('/me')),
-    ).subscribe();
+    http
+      .post('/auth/login', { username: 'foo', password: 'bar' })
+      .pipe(switchMap(() => http.get('/me')))
+      .subscribe();
 
     httpMock.expectOne('http://foo.bar/sanctum/csrf-cookie').flush({ cookie: true });
     httpMock.expectOne('/auth/login').flush({ login: true });
@@ -59,9 +61,10 @@ describe('SanctumInterceptor', () => {
   it('should get csrf cookie with sanctum prefix', () => {
     setBaseUrlAndSanctumPrefix('', 'foobar');
 
-    http.post('/auth/login', { username: 'foo', password: 'bar' }).pipe(
-      switchMap(() => http.get('/me')),
-    ).subscribe();
+    http
+      .post('/auth/login', { username: 'foo', password: 'bar' })
+      .pipe(switchMap(() => http.get('/me')))
+      .subscribe();
 
     httpMock.expectOne('/foobar/csrf-cookie').flush({ cookie: true });
     httpMock.expectOne('/auth/login').flush({ login: true });
@@ -71,9 +74,10 @@ describe('SanctumInterceptor', () => {
   it('should get csrf cookie with base url and sanctum prefix', () => {
     setBaseUrlAndSanctumPrefix('http://foo.bar/api', 'foobar');
 
-    http.post('/auth/login', { username: 'foo', password: 'bar' }).pipe(
-      switchMap(() => http.get('/me')),
-    ).subscribe();
+    http
+      .post('/auth/login', { username: 'foo', password: 'bar' })
+      .pipe(switchMap(() => http.get('/me')))
+      .subscribe();
 
     httpMock.expectOne('http://foo.bar/foobar/csrf-cookie').flush({ cookie: true });
     httpMock.expectOne('/auth/login').flush({ login: true });

--- a/src/app/core/interceptors/settings-interceptor.spec.ts
+++ b/src/app/core/interceptors/settings-interceptor.spec.ts
@@ -1,9 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 
-import { SettingsInterceptor } from './settings-interceptor';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
 import { SettingsService } from '../bootstrap/settings.service';
+import { SettingsInterceptor } from './settings-interceptor';
 
 describe('SettingsInterceptor', () => {
   let httpMock: HttpTestingController;
@@ -13,9 +13,7 @@ describe('SettingsInterceptor', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [
-        { provide: HTTP_INTERCEPTORS, useClass: SettingsInterceptor, multi: true },
-      ],
+      providers: [{ provide: HTTP_INTERCEPTORS, useClass: SettingsInterceptor, multi: true }],
     });
 
     httpMock = TestBed.inject(HttpTestingController);

--- a/src/app/core/interceptors/settings-interceptor.ts
+++ b/src/app/core/interceptors/settings-interceptor.ts
@@ -1,16 +1,17 @@
 import { Injectable } from '@angular/core';
 import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { SettingsService } from '@core/bootstrap/settings.service';
+import { SettingsService } from '../bootstrap/settings.service';
 
 @Injectable()
 export class SettingsInterceptor implements HttpInterceptor {
-
   constructor(private settings: SettingsService) {}
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-    return next.handle(request.clone({
-      headers: request.headers.append('Accept-Language', this.settings.language),
-    }));
+    return next.handle(
+      request.clone({
+        headers: request.headers.append('Accept-Language', this.settings.language),
+      })
+    );
   }
 }

--- a/src/app/theme/header/widgets/user.component.ts
+++ b/src/app/theme/header/widgets/user.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { MenuService } from '@core';
 import { AuthService } from '@core/authentication/auth.service';
-import { debounceTime, filter, tap } from 'rxjs/operators';
+import { debounceTime, tap } from 'rxjs/operators';
 import { User } from '@core/authentication/interface';
 
 @Component({
@@ -54,12 +54,6 @@ export class UserComponent implements OnInit {
   }
 
   logout() {
-    this.auth
-      .logout()
-      .pipe(filter(isLogout => isLogout))
-      .subscribe(() => {
-        this.menu.reset();
-        this.router.navigateByUrl('/auth/login');
-      });
+    this.auth.logout().subscribe();
   }
 }

--- a/src/app/theme/sidebar/user-panel.component.ts
+++ b/src/app/theme/sidebar/user-panel.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { AuthService } from '@core/authentication/auth.service';
 import { User } from '@core/authentication/interface';
 import { Router } from '@angular/router';
-import { filter } from 'rxjs/operators';
 
 @Component({
   selector: 'app-user-panel',
@@ -36,9 +35,6 @@ export class UserPanelComponent implements OnInit {
   }
 
   logout() {
-    this.auth
-      .logout()
-      .pipe(filter(isLogout => isLogout))
-      .subscribe(() => this.router.navigateByUrl('/auth/login'));
+    this.auth.logout().subscribe();
   }
 }


### PR DESCRIPTION
Next I want to make API /auth/login, /auth/logout, login username, router /auth/login these parameters can be set in Provider
This will be more flexible when using login behavior