### PR TITLE
move serve options out of serve configurations

### DIFF
--- a/schematics/ng-add/setup-project.ts
+++ b/schematics/ng-add/setup-project.ts
@@ -169,7 +169,7 @@ function addESLintToAngularJson(options: Schema): Rule {
 function addProxyToAngularJson(options: Schema) {
   return updateWorkspace(workspace => {
     const project = getProjectFromWorkspace(workspace, options.project);
-    const targetServeConfig = project.targets?.get('serve')?.configurations as any;
+    const targetServeConfig = project.targets?.get('serve') as any;
 
     if (targetServeConfig.options) {
       targetServeConfig.options.browserTarget = `${project.name}:build`;


### PR DESCRIPTION
for serve `options` to be effective it must be under the `serve` itself not its `configurations`