### PR TITLE
refactor: use `CanActivateFn` and `CanActivateChildFn` instead of `CanActivate` and `CanActivateChild`

### DIFF
--- a/schematics/ng-add/files/src/app/routes/routes-routing.module.ts
+++ b/schematics/ng-add/files/src/app/routes/routes-routing.module.ts
@@ -10,14 +10,14 @@ import { RegisterComponent } from './sessions/register/register.component';
 import { Error403Component } from './sessions/403.component';
 import { Error404Component } from './sessions/404.component';
 import { Error500Component } from './sessions/500.component';
-import { authenticate } from '@core';
+import { authGuard } from '@core';
 
 const routes: Routes = [
   {
     path: '',
     component: AdminLayoutComponent,
-    canActivate: [authenticate],
-    canActivateChild: [authenticate],
+    canActivate: [authGuard],
+    canActivateChild: [authGuard],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: 'dashboard', component: DashboardComponent },

--- a/schematics/ng-add/files/src/app/routes/routes-routing.module.ts
+++ b/schematics/ng-add/files/src/app/routes/routes-routing.module.ts
@@ -10,14 +10,14 @@ import { RegisterComponent } from './sessions/register/register.component';
 import { Error403Component } from './sessions/403.component';
 import { Error404Component } from './sessions/404.component';
 import { Error500Component } from './sessions/500.component';
-import { AuthGuard } from '@core';
+import { authenticate } from '@core';
 
 const routes: Routes = [
   {
     path: '',
     component: AdminLayoutComponent,
-    canActivate: [AuthGuard],
-    canActivateChild: [AuthGuard],
+    canActivate: [authenticate],
+    canActivateChild: [authenticate],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: 'dashboard', component: DashboardComponent },

--- a/src/app/core/authentication/auth.guard.spec.ts
+++ b/src/app/core/authentication/auth.guard.spec.ts
@@ -5,12 +5,12 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { LocalStorageService, MemoryStorageService } from '@shared/services/storage.service';
-import { TokenService, AuthService, authenticate } from '@core/authentication';
+import { TokenService, AuthService, authGuard } from '@core/authentication';
 
 @Component({ template: '' })
 class DummyComponent {}
 
-describe('authenticate guard function unit test', () => {
+describe('authGuard function unit test', () => {
   const route: any = {};
   const state: any = {};
   let router: Router;
@@ -22,7 +22,7 @@ describe('authenticate guard function unit test', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule.withRoutes([
-          { path: 'dashboard', component: DummyComponent, canActivate: [authenticate] },
+          { path: 'dashboard', component: DummyComponent, canActivate: [authGuard] },
           { path: 'auth/login', component: DummyComponent },
         ]),
       ],
@@ -36,14 +36,14 @@ describe('authenticate guard function unit test', () => {
   });
 
   it('should be created', () => {
-    expect(authenticate).toBeTruthy();
+    expect(authGuard).toBeTruthy();
   });
 
   it('should be authenticated', () => {
     inject([AuthService, Router], () => {
       tokenService.set({ access_token: 'token', token_type: 'bearer' });
 
-      expect(authenticate(route, state)).toBeTrue();
+      expect(authGuard(route, state)).toBeTrue();
     });
   });
 
@@ -51,7 +51,7 @@ describe('authenticate guard function unit test', () => {
     inject([AuthService, Router], () => {
       spyOn(authService, 'check').and.returnValue(false);
 
-      expect(authenticate(route, state)).toEqual(router.parseUrl('/auth/login'));
+      expect(authGuard(route, state)).toEqual(router.parseUrl('/auth/login'));
     });
   });
 });

--- a/src/app/core/authentication/auth.guard.spec.ts
+++ b/src/app/core/authentication/auth.guard.spec.ts
@@ -1,20 +1,19 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 
 import { Router } from '@angular/router';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { LocalStorageService, MemoryStorageService } from '@shared/services/storage.service';
-import { TokenService, AuthGuard, AuthService } from '@core/authentication';
+import { TokenService, AuthService, authenticate } from '@core/authentication';
 
 @Component({ template: '' })
 class DummyComponent {}
 
-describe('AuthGuard', () => {
+describe('authenticate guard function unit test', () => {
   const route: any = {};
   const state: any = {};
   let router: Router;
-  let authGuard: AuthGuard;
   let authService: AuthService;
   let tokenService: TokenService;
 
@@ -23,7 +22,7 @@ describe('AuthGuard', () => {
       imports: [
         HttpClientTestingModule,
         RouterTestingModule.withRoutes([
-          { path: 'dashboard', component: DummyComponent, canActivate: [AuthGuard] },
+          { path: 'dashboard', component: DummyComponent, canActivate: [authenticate] },
           { path: 'auth/login', component: DummyComponent },
         ]),
       ],
@@ -31,26 +30,28 @@ describe('AuthGuard', () => {
       providers: [{ provide: LocalStorageService, useClass: MemoryStorageService }],
     });
     TestBed.createComponent(DummyComponent);
-
     router = TestBed.inject(Router);
-    authGuard = TestBed.inject(AuthGuard);
     authService = TestBed.inject(AuthService);
     tokenService = TestBed.inject(TokenService);
   });
 
   it('should be created', () => {
-    expect(authGuard).toBeTruthy();
+    expect(authenticate).toBeTruthy();
   });
 
   it('should be authenticated', () => {
-    tokenService.set({ access_token: 'token', token_type: 'bearer' });
+    inject([AuthService, Router], () => {
+      tokenService.set({ access_token: 'token', token_type: 'bearer' });
 
-    expect(authGuard.canActivate(route, state)).toBeTrue();
+      expect(authenticate(route, state)).toBeTrue();
+    });
   });
 
   it('should redirect to /auth/login when authenticate failed', () => {
-    spyOn(authService, 'check').and.returnValue(false);
+    inject([AuthService, Router], () => {
+      spyOn(authService, 'check').and.returnValue(false);
 
-    expect(authGuard.canActivate(route, state)).toEqual(router.parseUrl('/auth/login'));
+      expect(authenticate(route, state)).toEqual(router.parseUrl('/auth/login'));
+    });
   });
 });

--- a/src/app/core/authentication/auth.guard.ts
+++ b/src/app/core/authentication/auth.guard.ts
@@ -2,7 +2,7 @@ import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
 import { AuthService } from './auth.service';
 
-export const authenticate = (route?: ActivatedRouteSnapshot, state?: RouterStateSnapshot) => {
+export const authGuard = (route?: ActivatedRouteSnapshot, state?: RouterStateSnapshot) => {
   const auth = inject(AuthService);
   const router = inject(Router);
 

--- a/src/app/core/authentication/auth.guard.ts
+++ b/src/app/core/authentication/auth.guard.ts
@@ -1,32 +1,10 @@
-import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  CanActivateChild,
-  Router,
-  RouterStateSnapshot,
-  UrlTree,
-} from '@angular/router';
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
 import { AuthService } from './auth.service';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class AuthGuard implements CanActivate, CanActivateChild {
-  constructor(private auth: AuthService, private router: Router) {}
+export const authenticate = (route?: ActivatedRouteSnapshot, state?: RouterStateSnapshot) => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
 
-  canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    return this.authenticate();
-  }
-
-  canActivateChild(
-    childRoute: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
-  ): boolean | UrlTree {
-    return this.authenticate();
-  }
-
-  private authenticate(): boolean | UrlTree {
-    return this.auth.check() ? true : this.router.parseUrl('/auth/login');
-  }
-}
+  return auth.check() ? true : router.parseUrl('/auth/login');
+};

--- a/src/app/routes/routes-routing.module.ts
+++ b/src/app/routes/routes-routing.module.ts
@@ -10,14 +10,14 @@ import { RegisterComponent } from './sessions/register/register.component';
 import { Error403Component } from './sessions/403.component';
 import { Error404Component } from './sessions/404.component';
 import { Error500Component } from './sessions/500.component';
-import { AuthGuard } from '@core/authentication';
+import { authenticate } from '@core/authentication';
 
 const routes: Routes = [
   {
     path: '',
     component: AdminLayoutComponent,
-    canActivate: [AuthGuard],
-    canActivateChild: [AuthGuard],
+    canActivate: [authenticate],
+    canActivateChild: [authenticate],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: 'dashboard', component: DashboardComponent },

--- a/src/app/routes/routes-routing.module.ts
+++ b/src/app/routes/routes-routing.module.ts
@@ -10,14 +10,14 @@ import { RegisterComponent } from './sessions/register/register.component';
 import { Error403Component } from './sessions/403.component';
 import { Error404Component } from './sessions/404.component';
 import { Error500Component } from './sessions/500.component';
-import { authenticate } from '@core/authentication';
+import { authGuard } from '@core/authentication';
 
 const routes: Routes = [
   {
     path: '',
     component: AdminLayoutComponent,
-    canActivate: [authenticate],
-    canActivateChild: [authenticate],
+    canActivate: [authGuard],
+    canActivateChild: [authGuard],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: 'dashboard', component: DashboardComponent },


### PR DESCRIPTION
BREAKCHANGE: `AuthGuard` is removed`, please use  new `authGuard` function

close #500