### PR TITLE
docs: update documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Ng-Matero is an Angular admin template made with Material components.
 
 ## 📖 Documentation
 
-[English](https://nzbin.gitbook.io/ng-matero/v/en-2/) ｜[简体中文](https://nzbin.gitbook.io/ng-matero/)
+[English](https://nzbin.gitbook.io/ng-matero/v/en-2/) ｜[简体中文](https://nzbin.gitbook.io/ng-matero/v/zh-1/)
 
 ## 📦 Compatibility
 


### PR DESCRIPTION
The old link still point to the english version by default.