### PR TITLE
fix: run 'npm run build:schematics' on Windows

### DIFF
--- a/schematics/package.json
+++ b/schematics/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://ng-matero.github.io/ng-matero/",
   "scripts": {
-    "build": "../node_modules/.bin/tsc -p tsconfig.json"
+    "build": "npx tsc -p tsconfig.json"
   },
   "schematics": "./collection.json",
   "ng-update": {


### PR DESCRIPTION
```powershell
PS C:\Users\xxx> npm run build:schematics

> ng-matero@0.0.0-NOT-USED build:schematics
> npm run copy:schematics && cd schematics && npm run build && cd .. && npm run build:starter


> ng-matero@0.0.0-NOT-USED copy:schematics
> npm run clean:schematics && cpr schematics dist/schematics


> ng-matero@0.0.0-NOT-USED clean:schematics
> rimraf dist/schematics


> ng-matero@17.1.0 build
> ../node_modules/.bin/tsc -p tsconfig.json

'..' 不是內部或外部命令、可執行的程式或批次檔。
```
------

The term '..' is not recognized as a name of a cmdlet, function, script file, or executable program.

-------